### PR TITLE
Update netdata image version to v1.45.0

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -45,7 +45,7 @@ buildah config --entrypoint=/ \
     --label="org.nethserver.authorizations=traefik@node:routeadm node:fwadm" \
     --label="org.nethserver.tcp-ports-demand=1" \
     --label="org.nethserver.rootfull=1" \
-    --label="org.nethserver.images=docker.io/netdata/netdata:v1.44.3" \
+    --label="org.nethserver.images=docker.io/netdata/netdata:v1.45.0" \
     "${container}"
 # Commit the image
 buildah commit "${container}" "${repobase}/${reponame}"

--- a/imageroot/update-module.d/20restart
+++ b/imageroot/update-module.d/20restart
@@ -12,4 +12,4 @@ set -e
 # Redirect any output to the journal (stderr)
 exec 1>&2
 
-systemctl --user try-restart netdata.service
+systemctl try-restart "${MODULE_ID}.service"


### PR DESCRIPTION
This pull request updates the netdata image version to v1.45.0 and modifies the restart command in the 20restart script to use the MODULE_ID variable instead of hardcoding the service name.