### PR TITLE
fix:  start netdata after redis

### DIFF
--- a/imageroot/netdata.service
+++ b/imageroot/netdata.service
@@ -5,7 +5,7 @@
 
 [Unit]
 Description=Netdata node monitoring
-After=network.target
+After=network.target redis.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n


### PR DESCRIPTION
see https://community.nethserver.org/t/netdata-ns8-not-start/23819

Netdata is started before redis and it could not start, we got the same issue with crowdsec


https://github.com/NethServer/dev/issues/6944