### PR TITLE
fix: ensure logo image is generated

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/javascript-node
 {
-  "name": "ns8-kickstart",
+  "name": "ns8-netdata",
   "image": "mcr.microsoft.com/devcontainers/javascript-node:0-18-bullseye",
   // Configure tool-specific properties.
   "customizations": {

--- a/ui/vue.config.js
+++ b/ui/vue.config.js
@@ -8,4 +8,15 @@ module.exports = {
       },
     },
   },
+  chainWebpack: (config) => {
+    config.module
+      .rule("images")
+      .use("url-loader")
+      .loader("url-loader")
+      .tap((options) => {
+        // Do not base64 encode images URLs. Needed to always generate module logo image
+        options.limit = -1;
+        return options;
+      });
+  },
 };


### PR DESCRIPTION
By default vue-cli-service does not generate images smaller than 4KB but replaces them with inline base64. This change ensures that image files (like module logo) are always generated, regardless of their size.

See:
- https://github.com/NethServer/dev/issues/6954

Other changes:
- Rename vscode devcontainer name