### PR TITLE
Refactor netdata.service to improve podman stop behavior

### DIFF
--- a/imageroot/netdata.service
+++ b/imageroot/netdata.service
@@ -45,7 +45,6 @@ ExecStart=/usr/bin/podman run \
      ${NETDATA_IMAGE} \
         -W set statsd enabled no
 
-ExecStop=/usr/bin/podman kill --signal INT %N
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/%N.cid -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/%N.cid
 PIDFile=%t/%N.pid


### PR DESCRIPTION
This pull request refactors the `netdata.service` file to improve the behavior of the `podman stop` command. 

The new Netadata version fixes the handling of TERM signal. The INT signal can now be removed.

https://github.com/NethServer/dev/issues/7076